### PR TITLE
Lowercase karma token

### DIFF
--- a/scripts/learn_karma.py
+++ b/scripts/learn_karma.py
@@ -20,6 +20,7 @@ for line in char_stream:
     viva_match = viva.match(line)
     if viva_match:
         element = viva_match.group(2).replace("'", "\\'")
+        element = element.lower()
         if element in karma:
             karma[element] += 1
         else:
@@ -28,6 +29,7 @@ for line in char_stream:
         abbasso_match = abbasso.match(line)
         if abbasso_match:
 	    element = abbasso_match.group(2).replace("'", "\\'")
+        element = element.lower()
             if element in karma:
                 karma[element] -= 1
             else:
@@ -46,6 +48,6 @@ for i,n in karma.iteritems():
         end = ",\n"
     else:
         end = "\n"
-	
+
     print("\t'%s' => '%d'" % (i.encode('utf-8') ,n), end=end)
 print ("};")

--- a/scripts/script-znc.py
+++ b/scripts/script-znc.py
@@ -21,6 +21,7 @@ for line in char_stream:
     viva_match = viva.match(line)
     if viva_match:
         element = viva_match.group("toBeIncreased").replace("'", "\\'")
+        element = element.lower()
         if element in karma:
             karma[element] += 1
         else:
@@ -29,10 +30,11 @@ for line in char_stream:
         abbasso_match = abbasso.match(line)
         if abbasso_match:
 	    element = abbasso_match.group("toBeDecreased").replace("'", "\\'")
-            if element in karma:
-                karma[element] -= 1
-            else:
-                karma[element] = -1
+        element = element.lower()
+        if element in karma:
+            karma[element] -= 1
+        else:
+            karma[element] = -1
 
 db = sqlite3.connect('karma.db')
 

--- a/scripts/script-znc.py
+++ b/scripts/script-znc.py
@@ -29,7 +29,7 @@ for line in char_stream:
     else:
         abbasso_match = abbasso.match(line)
         if abbasso_match:
-	    element = abbasso_match.group("toBeDecreased").replace("'", "\\'")
+        element = abbasso_match.group("toBeDecreased").replace("'", "\\'")
         element = element.lower()
         if element in karma:
             karma[element] -= 1


### PR DESCRIPTION
The ReKarma plugin lowercases the karma token before incrementing/decrementing its value.

With this PR I'd like to normalize the token before inserting it in the database.

## Example
Before
```
ANTANI => 3,
AnTaNI => 1,
antani => 1
```
After
```
antani => 5
```